### PR TITLE
Calculate a single CPU percentile for a combined pod CPU usage rather than per pod

### DIFF
--- a/robusta_krr/core/integrations/prometheus/metrics/base.py
+++ b/robusta_krr/core/integrations/prometheus/metrics/base.py
@@ -201,7 +201,12 @@ class PrometheusMetric(BaseMetric):
         if self.filtering:
             result = self.filter_prom_jobs_results(result)
 
-        return {pod_result["metric"]["pod"]: np.array(pod_result["values"], dtype=np.float64) for pod_result in result}
+        if self.__class__.__name__ == "PercentileCPULoader":
+            if len(result) != 1:
+                raise RuntimeError("Expected just 1 result for PercentileCPULoader")
+            return {object.name: np.array(pod_result["values"], dtype=np.float64) for pod_result in result}
+        else:
+            return {pod_result["metric"]["pod"]: np.array(pod_result["values"], dtype=np.float64) for pod_result in result}
 
     # --------------------- Filtering Jobs --------------------- #
 

--- a/robusta_krr/core/integrations/prometheus/metrics/cpu.py
+++ b/robusta_krr/core/integrations/prometheus/metrics/cpu.py
@@ -23,7 +23,7 @@ class CPULoader(PrometheusMetric):
                         {cluster_label}
                     }}[{step}]
                 )
-            ) by (container, pod, job)
+            ) by (container, job)
         """
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data handling for percentile CPU metrics to ensure correct processing when only a single result is expected.
  * Adjusted CPU usage aggregation to group metrics by container and job, rather than by container, pod, and job, which may affect the granularity of reported CPU usage data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->